### PR TITLE
移除外部宏及在vs2015环境使用std::shared_ptr

### DIFF
--- a/Paladin/CMakeLists.txt
+++ b/Paladin/CMakeLists.txt
@@ -7,13 +7,6 @@ project (Paladin)
 # 使用C++11特性
 add_definitions (-std=c++11)
 
-# 加入一个配置头文件，用于处理外部定义宏
-configure_file (
-  "${PROJECT_SOURCE_DIR}/src/tools/macro_config.h.in"
-  "${PROJECT_SOURCE_DIR}/src/tools/macro_config.h"
-  )
-option (PALADIN_HAVE_ALIGNED_MALLOC "Use _aligned_malloc function" OFF)
-
 # 收集所有头文件源文件，存入ALL_FILES变量中
 file(GLOB_RECURSE ALL_FILES "*.h" "*.h??" "*.cpp")
 

--- a/Paladin/src/core/header.h
+++ b/Paladin/src/core/header.h
@@ -32,6 +32,9 @@
     #include <string>
     //fix “max”: 不是“std”的成员 for vs2015
     #include <algorithm>
+    //fix “shared_ptr”: 不是“std”的成员 for vs2015
+    #include <memory>
+    
 #endif
 
 #include "stringprint.hpp"

--- a/Paladin/src/tools/macro.h
+++ b/Paladin/src/tools/macro.h
@@ -9,7 +9,6 @@
 #ifndef macro_hpp
 #define macro_hpp
 
-#include "macro_config.h"
 #include "header.h"
 
 #define CONSTEXPR constexpr
@@ -37,7 +36,7 @@
 
 #define PALADIN_HAVE_CONSTEXPR
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_MSC_VER)
     #define PALADIN_HAVE_ALIGNED_MALLOC
 #endif
 

--- a/Paladin/src/tools/macro_config.h
+++ b/Paladin/src/tools/macro_config.h
@@ -1,1 +1,0 @@
-/* #undef PALADIN_HAVE_ALIGNED_MALLOC */

--- a/Paladin/src/tools/macro_config.h.in
+++ b/Paladin/src/tools/macro_config.h.in
@@ -1,1 +1,0 @@
-#cmakedefine PALADIN_HAVE_ALIGNED_MALLOC


### PR DESCRIPTION
目前暂时不需要在CMakeLists.txt中引入外部宏，故删掉